### PR TITLE
Fix PageTheme crash on Android SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,7 +133,7 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.okaythis.sdk:psa:1.8.10'
+  implementation 'com.okaythis.sdk:psa:1.8.17'
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.1")
   implementation 'com.jakewharton.timber:timber:5.0.1'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.0'

--- a/android/src/main/java/com/reactnativeokaysdk/OkaySdkModule.kt
+++ b/android/src/main/java/com/reactnativeokaysdk/OkaySdkModule.kt
@@ -268,7 +268,7 @@ class OkaySdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJav
       val pageTheme = initPageTheme(pageThemeMap, promise)
       SpaAuthorizationData(sessionId.toLong(), appPNS, pageTheme, psaType)
     } else {
-      SpaAuthorizationData(sessionId.toLong(), appPNS, DefaultPageTheme.getDefaultPageTheme(reactContext), psaType)
+      SpaAuthorizationData(sessionId.toLong(), appPNS, null, psaType)
     }
     PsaManager.startAuthorizationActivity(activity, authorizationData)
   }


### PR DESCRIPTION
Bumped Android SDK from version 1.8.10 tp 1.8.17. This change allows clients to pass null as their PageTheme value if they do not want to customise the default Okay theme.